### PR TITLE
Use composite value as Station PK

### DIFF
--- a/app/migrations/0001_initial.py
+++ b/app/migrations/0001_initial.py
@@ -15,11 +15,11 @@ class Migration(migrations.Migration):
             fields=[
                 (
                     "id",
-                    models.BigAutoField(
-                        auto_created=True,
+                    models.CharField(
+                        max_length=155,
                         primary_key=True,
                         serialize=False,
-                        verbose_name="ID",
+                        editable=False,
                     ),
                 ),
                 ("created", models.DateTimeField(auto_now_add=True)),

--- a/app/models.py
+++ b/app/models.py
@@ -16,6 +16,7 @@ class TimeStampedModel(models.Model):
 class Station(TimeStampedModel):
     """Represent a bike station returned by the JCDecaux API."""
 
+    id = models.CharField(max_length=155, primary_key=True, editable=False)
     number = models.PositiveIntegerField()
     contract_name = models.CharField(max_length=100)
     name = models.CharField(max_length=255)
@@ -36,6 +37,11 @@ class Station(TimeStampedModel):
         ordering = ["contract_name", "number"]
         indexes = [models.Index(fields=["contract_name", "number"])]
         unique_together = ("contract_name", "number")
+
+    def save(self, *args, **kwargs):
+        """Set the primary key based on contract and station number."""
+        self.id = f"{self.contract_name}-{self.number}"
+        super().save(*args, **kwargs)
 
     def __str__(self) -> str:  # pragma: no cover - trivial
         return f"{self.contract_name} {self.number} - {self.name}"


### PR DESCRIPTION
## Summary
- update initial migration to use a CharField primary key
- assign station.id to `contract_name-number` on save

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_685be40ffc148329b4a831ad77a36df4