### PR TITLE
Add asynchronous JCDecaux API client

### DIFF
--- a/libs/jcdecauxclient/__init__.py
+++ b/libs/jcdecauxclient/__init__.py
@@ -1,8 +1,10 @@
 from .client import JCDecauxClient
+from .async_client import JCDecauxAsyncClient
 from .models import Contract, Park, Position, Station, Stands
 
 __all__ = [
     "JCDecauxClient",
+    "JCDecauxAsyncClient",
     "Contract",
     "Park",
     "Position",

--- a/libs/jcdecauxclient/async_client.py
+++ b/libs/jcdecauxclient/async_client.py
@@ -1,0 +1,121 @@
+from typing import List, Optional
+
+import httpx
+
+from .models import Contract, Park, Position, Station, Stands
+
+API_BASE = "https://api.jcdecaux.com"
+
+
+class JCDecauxAsyncClient:
+    def __init__(self, api_key: str):
+        self.api_key = api_key
+        self.client = httpx.AsyncClient(params={"apiKey": api_key})
+
+    async def close(self) -> None:
+        await self.client.aclose()
+
+    async def __aenter__(self) -> "JCDecauxAsyncClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.close()
+
+    async def get_contracts(self) -> List[Contract]:
+        url = f"{API_BASE}/vls/v3/contracts"
+        resp = await self.client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+        return [Contract(**c) for c in data]
+
+    async def get_station(self, station_number: int, contract_name: str) -> Station:
+        url = f"{API_BASE}/vls/v3/stations/{station_number}"
+        params = {"contract": contract_name}
+        resp = await self.client.get(url, params=params)
+        if resp.status_code == 404:
+            raise ValueError(
+                f"Station {station_number} not found in contract {contract_name}"
+            )
+        resp.raise_for_status()
+        s = resp.json()
+        return self._parse_station(s)
+
+    async def list_stations(self, contract_name: Optional[str] = None) -> List[Station]:
+        url = f"{API_BASE}/vls/v3/stations"
+        params = {}
+        if contract_name:
+            params["contract"] = contract_name
+        resp = await self.client.get(url, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+        return [self._parse_station(s) for s in data]
+
+    async def list_parks(self, contract_name: str) -> List[Park]:
+        url = f"{API_BASE}/parking/v1/contracts/{contract_name}/parks"
+        resp = await self.client.get(url)
+        if resp.status_code == 400:
+            raise ValueError(
+                f"Contract {contract_name} not found or does not support parks API"
+            )
+        resp.raise_for_status()
+        data = resp.json()
+        return [self._parse_park(p) for p in data]
+
+    async def get_park(self, contract_name: str, park_number: int) -> Park:
+        url = f"{API_BASE}/parking/v1/contracts/{contract_name}/parks/{park_number}"
+        resp = await self.client.get(url)
+        if resp.status_code == 404:
+            raise ValueError(
+                f"Park {park_number} not found in contract {contract_name}"
+            )
+        resp.raise_for_status()
+        return self._parse_park(resp.json())
+
+    def _parse_station(self, data: dict) -> Station:
+        pos = Position(**data["position"])
+
+        def make_stands(obj):
+            av = obj["availabilities"]
+            return Stands(**av, capacity=obj.get("capacity"))
+
+        total = make_stands(data["totalStands"])
+        main = make_stands(data["mainStands"])
+        overflow = None
+        if data.get("overflowStands"):
+            overflow = make_stands(data["overflowStands"])
+        return Station(
+            number=data["number"],
+            contractName=data["contractName"],
+            name=data["name"],
+            address=data["address"],
+            position=pos,
+            banking=data["banking"],
+            bonus=data["bonus"],
+            status=data["status"],
+            lastUpdate=data["lastUpdate"],
+            connected=data["connected"],
+            overflow=data["overflow"],
+            totalStands=total,
+            mainStands=main,
+            overflowStands=overflow,
+        )
+
+    def _parse_park(self, data: dict) -> Park:
+        pos = Position(**data["position"])
+        return Park(
+            contractName=data["contractName"],
+            name=data["name"],
+            number=data["number"],
+            status=data["status"],
+            position=pos,
+            accessType=data["accessType"],
+            lockerType=data["lockerType"],
+            hasSurveillance=data["hasSurveillance"],
+            isFree=data["isFree"],
+            address=data["address"],
+            zipCode=data["zipCode"],
+            city=data["city"],
+            isOffStreet=data["isOffStreet"],
+            hasElectricSupport=data["hasElectricSupport"],
+            hasPhysicalReception=data["hasPhysicalReception"],
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ idna==3.10
 requests==2.32.4
 sqlparse==0.5.3
 urllib3==2.5.0
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- provide an async variant of the JCDecaux API client using `httpx`
- expose `JCDecauxAsyncClient` in the package
- include httpx in the requirements

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bed5ba9748329bba0e696b349c473