### PR TITLE
Refactor JCDecaux client constants

### DIFF
--- a/libs/jcdecauxclient/__init__.py
+++ b/libs/jcdecauxclient/__init__.py
@@ -1,7 +1,7 @@
-from .client import JCDecauxClient
 from .async_client import JCDecauxClientAsync
-from .models import Contract, Park, Position, Station, Stands
-from .constants import API_BASE
+from .client import JCDecauxClient
+from .constants import API_BASE_URL
+from .models import Contract, Park, Position, Stands, Station
 
 __all__ = [
     "JCDecauxClient",
@@ -11,5 +11,5 @@ __all__ = [
     "Position",
     "Station",
     "Stands",
-    "API_BASE",
+    "API_BASE_URL",
 ]

--- a/libs/jcdecauxclient/__init__.py
+++ b/libs/jcdecauxclient/__init__.py
@@ -1,11 +1,15 @@
 from .client import JCDecauxClient
+from .async_client import JCDecauxClientAsync
 from .models import Contract, Park, Position, Station, Stands
+from .constants import API_BASE
 
 __all__ = [
     "JCDecauxClient",
+    "JCDecauxClientAsync",
     "Contract",
     "Park",
     "Position",
     "Station",
     "Stands",
+    "API_BASE",
 ]

--- a/libs/jcdecauxclient/async_client.py
+++ b/libs/jcdecauxclient/async_client.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 
 import httpx
 
-from .models import Contract, Park, Position, Station, Stands
-from .constants import API_BASE
+from .constants import API_BASE_URL
+from .models import Contract, Park, Position, Stands, Station
 
 
 class JCDecauxClientAsync:
@@ -27,14 +27,14 @@ class JCDecauxClientAsync:
         await self.close()
 
     async def get_contracts(self) -> List[Contract]:
-        url = f"{API_BASE}/vls/v3/contracts"
+        url = f"{API_BASE_URL}/vls/v3/contracts"
         resp = await self.client.get(url)
         resp.raise_for_status()
         data = resp.json()
         return [Contract(**c) for c in data]
 
     async def get_station(self, station_number: int, contract_name: str) -> Station:
-        url = f"{API_BASE}/vls/v3/stations/{station_number}"
+        url = f"{API_BASE_URL}/vls/v3/stations/{station_number}"
         params = {"contract": contract_name}
         resp = await self.client.get(url, params=params)
         if resp.status_code == 404:
@@ -46,7 +46,7 @@ class JCDecauxClientAsync:
         return self._parse_station(s)
 
     async def list_stations(self, contract_name: Optional[str] = None) -> List[Station]:
-        url = f"{API_BASE}/vls/v3/stations"
+        url = f"{API_BASE_URL}/vls/v3/stations"
         params = {}
         if contract_name:
             params["contract"] = contract_name
@@ -56,7 +56,7 @@ class JCDecauxClientAsync:
         return [self._parse_station(s) for s in data]
 
     async def list_parks(self, contract_name: str) -> List[Park]:
-        url = f"{API_BASE}/parking/v1/contracts/{contract_name}/parks"
+        url = f"{API_BASE_URL}/parking/v1/contracts/{contract_name}/parks"
         resp = await self.client.get(url)
         if resp.status_code == 400:
             raise ValueError(
@@ -67,7 +67,7 @@ class JCDecauxClientAsync:
         return [self._parse_park(p) for p in data]
 
     async def get_park(self, contract_name: str, park_number: int) -> Park:
-        url = f"{API_BASE}/parking/v1/contracts/{contract_name}/parks/{park_number}"
+        url = f"{API_BASE_URL}/parking/v1/contracts/{contract_name}/parks/{park_number}"
         resp = await self.client.get(url)
         if resp.status_code == 404:
             raise ValueError(

--- a/libs/jcdecauxclient/client.py
+++ b/libs/jcdecauxclient/client.py
@@ -3,8 +3,8 @@ from typing import List, Optional
 
 import requests
 
-from .models import Contract, Park, Position, Station, Stands
-from .constants import API_BASE
+from .constants import API_BASE_URL
+from .models import Contract, Park, Position, Stands, Station
 
 
 class JCDecauxClient:
@@ -19,14 +19,14 @@ class JCDecauxClient:
         self.session.params = {"apiKey": api_key}
 
     def get_contracts(self) -> List[Contract]:
-        url = f"{API_BASE}/vls/v3/contracts"
+        url = f"{API_BASE_URL}/vls/v3/contracts"
         resp = self.session.get(url)
         resp.raise_for_status()
         data = resp.json()
         return [Contract(**c) for c in data]
 
     def get_station(self, station_number: int, contract_name: str) -> Station:
-        url = f"{API_BASE}/vls/v3/stations/{station_number}"
+        url = f"{API_BASE_URL}/vls/v3/stations/{station_number}"
         params = {"contract": contract_name}
         resp = self.session.get(url, params=params)
         if resp.status_code == 404:
@@ -38,7 +38,7 @@ class JCDecauxClient:
         return self._parse_station(s)
 
     def list_stations(self, contract_name: Optional[str] = None) -> List[Station]:
-        url = f"{API_BASE}/vls/v3/stations"
+        url = f"{API_BASE_URL}/vls/v3/stations"
         params = {}
         if contract_name:
             params["contract"] = contract_name
@@ -48,7 +48,7 @@ class JCDecauxClient:
         return [self._parse_station(s) for s in data]
 
     def list_parks(self, contract_name: str) -> List[Park]:
-        url = f"{API_BASE}/parking/v1/contracts/{contract_name}/parks"
+        url = f"{API_BASE_URL}/parking/v1/contracts/{contract_name}/parks"
         resp = self.session.get(url)
         if resp.status_code == 400:
             raise ValueError(
@@ -59,7 +59,7 @@ class JCDecauxClient:
         return [self._parse_park(p) for p in data]
 
     def get_park(self, contract_name: str, park_number: int) -> Park:
-        url = f"{API_BASE}/parking/v1/contracts/{contract_name}/parks/{park_number}"
+        url = f"{API_BASE_URL}/parking/v1/contracts/{contract_name}/parks/{park_number}"
         resp = self.session.get(url)
         if resp.status_code == 404:
             raise ValueError(

--- a/libs/jcdecauxclient/constants.py
+++ b/libs/jcdecauxclient/constants.py
@@ -1,3 +1,3 @@
 # Common constants for JCDecaux clients
 
-API_BASE = "https://api.jcdecaux.com"
+API_BASE_URL = "https://api.jcdecaux.com"

--- a/libs/jcdecauxclient/constants.py
+++ b/libs/jcdecauxclient/constants.py
@@ -1,0 +1,3 @@
+# Common constants for JCDecaux clients
+
+API_BASE = "https://api.jcdecaux.com"

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ idna==3.10
 requests==2.32.4
 sqlparse==0.5.3
 urllib3==2.5.0
+httpx==0.27.0


### PR DESCRIPTION
## Summary
- move API_BASE constant to dedicated constants module
- update sync and async clients to import API_BASE
- export API_BASE from package

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685bed5ba9748329bba0e696b349c473