### PR TITLE
Add module and class docstrings

### DIFF
--- a/libs/jcdecauxclient/__init__.py
+++ b/libs/jcdecauxclient/__init__.py
@@ -1,3 +1,5 @@
+"""Public interface for JCDecaux API clients and data models."""
+
 from .async_client import JCDecauxClientAsync
 from .client import JCDecauxClient
 from .constants import API_BASE_URL

--- a/libs/jcdecauxclient/async_client.py
+++ b/libs/jcdecauxclient/async_client.py
@@ -1,3 +1,5 @@
+"""Asynchronous client for interacting with the JCDecaux API."""
+
 import os
 from typing import List, Optional
 
@@ -8,6 +10,7 @@ from .models import Contract, Park, Position, Stands, Station
 
 
 class JCDecauxClientAsync:
+    """Asynchronous wrapper around the JCDecaux REST API using httpx."""
     def __init__(self, api_key: Optional[str] = None):
         api_key = api_key or os.environ.get("API_KEY")
         if not api_key:

--- a/libs/jcdecauxclient/client.py
+++ b/libs/jcdecauxclient/client.py
@@ -1,3 +1,5 @@
+"""Synchronous client for interacting with the JCDecaux API."""
+
 import os
 from typing import List, Optional
 
@@ -8,6 +10,7 @@ from .models import Contract, Park, Position, Stands, Station
 
 
 class JCDecauxClient:
+    """Convenience wrapper around the JCDecaux REST API using requests."""
     def __init__(self, api_key: Optional[str] = None):
         api_key = api_key or os.environ.get("API_KEY")
         if not api_key:

--- a/libs/jcdecauxclient/constants.py
+++ b/libs/jcdecauxclient/constants.py
@@ -1,3 +1,3 @@
-# Common constants for JCDecaux clients
+"""Constants for interacting with the JCDecaux public API."""
 
 API_BASE_URL = "https://api.jcdecaux.com"

--- a/libs/jcdecauxclient/models.py
+++ b/libs/jcdecauxclient/models.py
@@ -1,3 +1,5 @@
+"""Data models used by the JCDecaux API clients."""
+
 from dataclasses import dataclass, field
 from typing import List, Optional
 


### PR DESCRIPTION
## Summary
- document JCDecaux API helper modules
- explain synchronous and asynchronous client classes

## Testing
- `DJANGO_SETTINGS_MODULE=config.settings pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68629284e6d48329a54b84fd8e0c24a8