### PR TITLE
Configure ruff and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,12 @@ Running the Django development server after setting `API_KEY` allows the applica
 export API_KEY="<your api key>"
 python manage.py runserver
 ```
+
+## Linting with Ruff
+
+Ruff is configured via `pyproject.toml`. After installing it, run:
+
+```bash
+pip install ruff
+ruff check app tests libs config
+```

--- a/app/tests.py
+++ b/app/tests.py
@@ -1,3 +1,1 @@
-from django.test import TestCase
-
 # Create your tests here.

--- a/app/views.py
+++ b/app/views.py
@@ -1,3 +1,1 @@
-from django.shortcuts import render
-
 # Create your views here.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.ruff]
+line-length = 79
+src = ["app", "config", "libs", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F"]
+ignore = []
+


### PR DESCRIPTION
## Summary
- tweak Ruff configuration
- document how to run Ruff on all packages

## Testing
- `python manage.py test -v 2`
- `ruff check app tests libs config | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_6862966e70b48329969b113a118b79f8